### PR TITLE
Add support for Python 3.8, 3.9 in notebook 4

### DIFF
--- a/4_mstis_sampling_tutorial.ipynb
+++ b/4_mstis_sampling_tutorial.ipynb
@@ -218,10 +218,17 @@
    "outputs": [],
    "source": [
     "# some aspects of storage depend on Python version\n",
-    "if sys.version_info > (3,):\n",
+    "if sys.version_info < (3,):\n",
+    "    filename = \"./inputs/mstis_bootstrap_py2.nc\"\n",
+    "elif (3, 6) <= sys.version_info < (3, 8):\n",
     "    filename = \"./inputs/mstis_bootstrap_py3.nc\"\n",
+    "elif (3, 8) <= sys.version_info < (3, 10):\n",
+    "    filename = \"./inputs/mstis_bootstrap_py38.nc\"\n",
     "else:\n",
-    "    filename = \"./inputs/mstis_bootstrap_py2.nc\""
+    "    raise RuntimeError(\n",
+    "        \"Uh oh! Looks like we don't have an input file for your Python version: \"\n",
+    "        + \".\".join(str(x) for x in sys.version_info[:3])\n",
+    "    )"
    ]
   },
   {
@@ -606,7 +613,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.10"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
Details of serializing functions changed again in Python 3.8, so we need to add another input file for notebook 4. (This had not previously been an issue because until OpenMM released on conda-forge, we were tied to Python 3.7.)