### PR TITLE
Add github workflow to autobuild binder

### DIFF
--- a/.github/workflows/binder.yml
+++ b/.github/workflows/binder.yml
@@ -1,0 +1,14 @@
+name: "Build binder"
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-binder:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: s-weigand/trigger-mybinder-build@v1
+        with:
+          target-repo: openpathsampling/ops_tutorial


### PR DESCRIPTION
This will make it so that every merge/push to the main branch automatically triggers a build of the Binder image.