### PR TITLE
Fix Autobuild binder

### DIFF
--- a/.github/workflows/binder.yml
+++ b/.github/workflows/binder.yml
@@ -1,0 +1,14 @@
+name: "Build binder"
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-binder:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: s-weigand/trigger-mybinder-build@v1
+        with:
+          target-repo: openpathsampling/ops_tutorial

--- a/.github/workflows/binder.yml
+++ b/.github/workflows/binder.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - uses: s-weigand/trigger-mybinder-build@v1
         with:
-          target-repo: openpathsampling/ops_tutorial
+          target-repo: openpathsampling/ops_tutorial/main


### PR DESCRIPTION
Looks like we need to specify `main` branch. Fixes incomplete from #9.