### PR TITLE
Switch builder.openmm.org => OpenMM-Setup

### DIFF
--- a/1_tps_sampling_tutorial.ipynb
+++ b/1_tps_sampling_tutorial.ipynb
@@ -59,7 +59,7 @@
    "source": [
     "The next cell shows you how to set up several things specific to OpenMM. We'll be running in the $NVT$ ensemble, with $T=300 K$. We're using the [Velocity Verlet with Velocity Randomization (VVVR) integrator](http://arxiv.org/abs/1301.3800), which simulates Langevin dynamics. Note that the integrator itself comes from [`openmmtools`](https://github.com/choderalab/openmmtools), a library that extends OpenMM. You should always use a reversible integrator when performing path sampling simulations. The default integrators in OpenMM are leapfrog-based, and therefore not reversible.\n",
     "\n",
-    "You can learn a lot more about setting up OpenMM simulations from the [OpenMM documentation](http://docs.openmm.org/). However, it is often even easier to use the [OpenMM Script Builder](http://builder.openmm.org/) to learn how to set up the simulation the way you'd like."
+    "You can learn a lot more about setting up OpenMM simulations from the [OpenMM documentation](http://docs.openmm.org/). However, it is often even easier to use [OpenMM-Setup](https://github.com/openmm/openmm-setup/) to learn how to set up the simulation the way you'd like."
    ]
   },
   {


### PR DESCRIPTION
The browser-based OpenMM script writer is dead... long live the browser-based OpenMM script writer!

http://builder.openmm.org has been a dead link for a while. The still-in-development version of that tool is [OpenMM-Setup](https://github.com/openmm/openmm-setup), which is intended to run locally (presumably because it also supports a bunch of PDBFixer and related stuff to set up a simulation, which is too computationally expensive to run on openmm.org.)

This corrects notebook 1 to point to the right place to learn more about OpenMM. This is one of the issues listed in #15.